### PR TITLE
Fix hitbox bug while riding

### DIFF
--- a/src/main/java/com/glebtik/headjar/jars/HeadJar.java
+++ b/src/main/java/com/glebtik/headjar/jars/HeadJar.java
@@ -73,7 +73,10 @@ public class HeadJar implements IJar {
         player.height = 0.75f;
         player.width = 0.7f;
         player.eyeHeight = 0.5f;
-        if(player.isRiding()) player.eyeHeight = 0.75f;
+        if(player.isRiding()) {
+            player.height = 1.25f;
+            player.eyeHeight = 0.75f;
+        }
 
     }
 }

--- a/src/main/java/com/glebtik/headjar/jars/HeadJar.java
+++ b/src/main/java/com/glebtik/headjar/jars/HeadJar.java
@@ -74,7 +74,7 @@ public class HeadJar implements IJar {
         player.width = 0.7f;
         player.eyeHeight = 0.5f;
         if(player.isRiding()) {
-            player.height = 1.25f;
+            player.height = 1.23f;
             player.eyeHeight = 0.75f;
         }
 


### PR DESCRIPTION
Fixing the hitbox while riding by extending the hitbox up. The bug is caused by a [Minecraft Bug](https://bugs.mojang.com/browse/MC-80876?jql=labels%20%3D%20HItbox) and can only be resolved this way, because the offset relative to the ridden entity can not be changed.